### PR TITLE
Feat: 부스 디테일 페이지 UI

### DIFF
--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -3,7 +3,7 @@
   top: 0;
   width: 100%;
   height: 10px;
-  z-index: 1;
+  z-index: 5;
   padding: 30px 0 30px 0px; /*상좌하우 */
   display: flex;
   justify-content: space-between;
@@ -13,6 +13,7 @@
   background-color: #1b2f4e;
   margin: 0 10px 0 0;
   font-family: 'GmarketSansMedium';
+  transform: translate3d(0, 0, 0);
 }
 
 .nav__logo {

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -41,7 +41,7 @@ export default function Navbar() {
   useEffect(() => {
     //리스너 등록
     window.addEventListener('scroll', () => {
-      console.log('window.scrollY', window.scrollY);
+      // console.log('window.scrollY', window.scrollY);
       if (window.scrollY > 50) {
         setShow(true);
       } else {

--- a/src/pages/Booth/BoothDetail.js
+++ b/src/pages/Booth/BoothDetail.js
@@ -10,15 +10,23 @@ import {
   DateLocContainer,
   LocationMap,
   BoothNotification,
+  BoothNotificationOpen,
+  IntroContainer,
+  IntroLine,
+  IntroContent,
+  MenuContainer,
+  MenuItem,
 } from './style';
 import NoticeExImg from '../../assets/img/noticeExImg.png';
 import MapIconImg from '../../assets/img/mainMapIcon.png';
+import BoothdetailC from '../../assets/img/boothdetailC.png';
 import { UpTitle } from '../../styles/style';
 
 // External Libraries //
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import SwiperCore, { Pagination, Autoplay } from 'swiper';
 import 'swiper/scss';
@@ -39,7 +47,7 @@ export default function BoothDetail() {
     notice: '호떡이 참 맛있는 맛집',
     startAt: '2022-09-23',
     content:
-      '맛있는 호떡 먹고 가세요~ 맛있는 호떡 먹고 가세요 피자, 슈크림, 등 다양한 맛을 판매 중입니다.~',
+      '맛있는 호떡 먹고 가세요~맛있는 호떡 먹고 가세요 피자, 슈크림, 등 다양한 맛을 판매중 입니다.~<br/>코로나 19를 딛고 다시 힘차게 오픈하게 된 저희 불닭볶음밥 전문점, 원조 「교테전 불닭볶음밥 식당」을 찾아주신 고객님들 환영합니다 *^^*<br/><br/>기본적으로 치즈가 듬뿍 올라가게 되어 맵지가 않으니 매운 음식을 마다하시는 분들도 맛나게 드실 수 있습니다.<br/>특히, 요 근래 유행하는 콘치즈를 얹어 먹으면 아이들에게도 인기만점! 한끼 식사거리가 될 수 있답니다.<br/><br/>여러분들께서도 공강시간에 배고프실 때, 든든히 먹을 수 있는 밥을 한끼 찾고 계시다면 우리 원조 「교테전 불닭볶음밥 식당」을 찾아주시기 바랍니다.',
     images: [
       {
         url: NoticeExImg,
@@ -67,11 +75,49 @@ export default function BoothDetail() {
     },
   ]);
 
+  // toggle //
+  const [intro, setIntro] = useState(false);
+  const [noticeToggle, setNoticeToggle] = useState(false);
+
+  // 슬라이드 뷰 //
   const SlideView = booth.images.map((b, idx) => {
     return (
       <SwiperSlide key={idx}>
         <img src={b.url} style={{ width: '325px', borderRadius: '2px' }} />
       </SwiperSlide>
+    );
+  });
+
+  // 주점 소개 뷰 //
+  const IntroView = () => {
+    return intro ? (
+      <IntroContent
+        dangerouslySetInnerHTML={{ __html: booth.content }}
+      ></IntroContent>
+    ) : (
+      <>
+        <IntroContent
+          dangerouslySetInnerHTML={{ __html: booth.content.slice(0, 50) }}
+        ></IntroContent>
+        <span
+          style={{ fontSize: '12px', cursor: 'pointer' }}
+          onClick={() => {
+            setIntro(true);
+          }}
+        >
+          ... 더보기
+        </span>
+      </>
+    );
+  };
+
+  // 메뉴 소개 뷰 //
+  const MenuView = menu.map((m, idx) => {
+    return (
+      <MenuItem key={idx}>
+        <div>{m.name}</div>
+        <div style={{ fontSize: '12px' }}>{m.price}원</div>
+      </MenuItem>
     );
   });
 
@@ -113,13 +159,51 @@ export default function BoothDetail() {
             {booth.location}
           </LocationMap>
         </DateLocContainer>
-        <BoothNotification>
-          <NotificationsIcon
-            style={{ fontSize: '16px', margin: '6px 6px 0 14px' }}
-          />
-          <div>부스 공지사항</div>
-          <KeyboardArrowDownIcon style={{ margin: '3px 14px 6px auto' }} />
-        </BoothNotification>
+
+        {/* 부스 공지사항 */}
+        {noticeToggle ? (
+          <BoothNotificationOpen>
+            <div>
+              <NotificationsIcon
+                style={{ fontSize: '16px', margin: '6px 6px 0 14px' }}
+              />
+              <div>부스 공지사항</div>
+              <KeyboardArrowUpIcon style={{ margin: '3px 14px 6px auto' }} />
+            </div>
+          </BoothNotificationOpen>
+        ) : (
+          <BoothNotification
+            onClick={() => {
+              setNoticeToggle(true);
+            }}
+          >
+            <NotificationsIcon
+              style={{ fontSize: '16px', margin: '6px 6px 0 14px' }}
+            />
+            <div>부스 공지사항</div>
+            <KeyboardArrowDownIcon style={{ margin: '3px 14px 6px auto' }} />
+          </BoothNotification>
+        )}
+
+        {/* 부스 주점 소개 */}
+        <IntroContainer>
+          <div className="introtitle">
+            <img src={BoothdetailC} width="36px" />
+            <span>주점 소개</span>
+          </div>
+          <IntroLine></IntroLine>
+          {IntroView()}
+        </IntroContainer>
+
+        {/* 부스 메뉴 소개 */}
+        <IntroContainer>
+          <div className="introtitle">
+            <img src={BoothdetailC} width="36px" />
+            <span>메뉴</span>
+          </div>
+          <IntroLine></IntroLine>
+          <MenuContainer>{MenuView}</MenuContainer>
+        </IntroContainer>
       </ContentContainer>
     </div>
   );

--- a/src/pages/Booth/BoothDetail.js
+++ b/src/pages/Booth/BoothDetail.js
@@ -24,6 +24,7 @@ import { UpTitle } from '../../styles/style';
 
 // External Libraries //
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import FavoriteIcon from '@mui/icons-material/Favorite';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
@@ -44,7 +45,8 @@ export default function BoothDetail() {
       korean: '주점',
     },
     location: '명진관 9번',
-    notice: '호떡이 참 맛있는 맛집',
+    notice:
+      '16일 우천시에도 운영합니다! <br/>*교공 하트키링 판매중(3000원, 한정수량)<br/><br/>[운영 시간] 10:00 - 16:00 (품절시 마감 공지)<br/>[운영 위치] 교육관 7번 부스<br/><br/>*교육관 생각보다 안멀어요!! (포관쪽에서 5분 소요) 드셔보세요ヾ(•ω•`)o*<br/><br/>**주인장의 꿀팁: 콘치즈랑 팝콘치킨을 모두 추가한 게 제일 맛있습니다(메인 메뉴임)**',
     startAt: '2022-09-23',
     content:
       '맛있는 호떡 먹고 가세요~맛있는 호떡 먹고 가세요 피자, 슈크림, 등 다양한 맛을 판매중 입니다.~<br/>코로나 19를 딛고 다시 힘차게 오픈하게 된 저희 불닭볶음밥 전문점, 원조 「교테전 불닭볶음밥 식당」을 찾아주신 고객님들 환영합니다 *^^*<br/><br/>기본적으로 치즈가 듬뿍 올라가게 되어 맵지가 않으니 매운 음식을 마다하시는 분들도 맛나게 드실 수 있습니다.<br/>특히, 요 근래 유행하는 콘치즈를 얹어 먹으면 아이들에게도 인기만점! 한끼 식사거리가 될 수 있답니다.<br/><br/>여러분들께서도 공강시간에 배고프실 때, 든든히 먹을 수 있는 밥을 한끼 찾고 계시다면 우리 원조 「교테전 불닭볶음밥 식당」을 찾아주시기 바랍니다.',
@@ -74,10 +76,12 @@ export default function BoothDetail() {
       price: '1000',
     },
   ]);
+  const [lovecnt, setLovecnt] = useState(100);
 
   // toggle //
   const [intro, setIntro] = useState(false);
   const [noticeToggle, setNoticeToggle] = useState(false);
+  const [love, setLove] = useState(false);
 
   // 슬라이드 뷰 //
   const SlideView = booth.images.map((b, idx) => {
@@ -87,6 +91,31 @@ export default function BoothDetail() {
       </SwiperSlide>
     );
   });
+
+  // 좋아요 기능 //
+  const HeartView = (tp) => {
+    console.log(tp);
+    return love ? (
+      <FavoriteIcon
+        onClick={() => {
+          setLove(false);
+        }}
+        style={{
+          fontSize: '28px',
+          color: `${
+            tp === '주점' ? '#ff6b6b' : tp === '부스' ? '#0b9908' : '#2676ee'
+          }`,
+        }}
+      />
+    ) : (
+      <FavoriteBorderIcon
+        onClick={() => {
+          setLove(true);
+        }}
+        style={{ fontSize: '28px' }}
+      />
+    );
+  };
 
   // 주점 소개 뷰 //
   const IntroView = () => {
@@ -147,9 +176,9 @@ export default function BoothDetail() {
         <br />
 
         <div style={{ display: 'flex', alignItem: 'center' }}>
-          <FavoriteBorderIcon style={{ fontSize: '28px' }} />
+          {HeartView(booth.boothType.korean)}
           &nbsp;
-          <LikeCnt>100</LikeCnt>
+          <LikeCnt>{lovecnt}</LikeCnt>
         </div>
 
         <DateLocContainer>
@@ -162,14 +191,22 @@ export default function BoothDetail() {
 
         {/* 부스 공지사항 */}
         {noticeToggle ? (
-          <BoothNotificationOpen>
-            <div>
+          <BoothNotificationOpen
+            onClick={() => {
+              setNoticeToggle(false);
+            }}
+          >
+            <div className="bar">
               <NotificationsIcon
                 style={{ fontSize: '16px', margin: '6px 6px 0 14px' }}
               />
               <div>부스 공지사항</div>
               <KeyboardArrowUpIcon style={{ margin: '3px 14px 6px auto' }} />
             </div>
+            <div
+              className="notice"
+              dangerouslySetInnerHTML={{ __html: booth.notice }}
+            ></div>
           </BoothNotificationOpen>
         ) : (
           <BoothNotification
@@ -203,6 +240,15 @@ export default function BoothDetail() {
           </div>
           <IntroLine></IntroLine>
           <MenuContainer>{MenuView}</MenuContainer>
+        </IntroContainer>
+
+        {/* 방명록 */}
+        <IntroContainer>
+          <div className="introtitle">
+            <img src={BoothdetailC} width="36px" />
+            <span>방명록</span>
+          </div>
+          <IntroLine></IntroLine>
         </IntroContainer>
       </ContentContainer>
     </div>

--- a/src/pages/Booth/BoothDetail.js
+++ b/src/pages/Booth/BoothDetail.js
@@ -152,7 +152,10 @@ export default function BoothDetail() {
 
   return (
     <div style={{ marginBottom: '76px' }}>
-      <UpTitle title={`${booth.boothType.korean} 홈페이지`} mapleLeft="57px" />
+      <UpTitle
+        title={`${booth.boothType.korean} 홈페이지`}
+        mapleLeft={booth.boothType.korean === '푸드트럭' ? '30px' : '57px'}
+      />
 
       {/* 스와이퍼 */}
       <SwiperContainer>

--- a/src/pages/Booth/BoothDetail.js
+++ b/src/pages/Booth/BoothDetail.js
@@ -7,13 +7,18 @@ import {
   BoothTitle,
   BoothIntro,
   LikeCnt,
+  DateLocContainer,
+  LocationMap,
+  BoothNotification,
 } from './style';
 import NoticeExImg from '../../assets/img/noticeExImg.png';
-// import BoothDetailMap from '../../assets/img/boothdetailMap.png';
+import MapIconImg from '../../assets/img/mainMapIcon.png';
 import { UpTitle } from '../../styles/style';
 
 // External Libraries //
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import NotificationsIcon from '@mui/icons-material/Notifications';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import SwiperCore, { Pagination, Autoplay } from 'swiper';
 import 'swiper/scss';
@@ -23,14 +28,16 @@ import 'swiper/scss/pagination';
 SwiperCore.use([Pagination, Autoplay]);
 
 export default function BoothDetail() {
+  // 더미 데이터 (추후 수정)
   const [booth, setBooth] = useState({
     title: '명진관 호떡',
     introduction: '맛있는 호떡과 다양한 음식',
-    type: '주점',
-    location: '명진관',
-    // location_img: BoothDetailMap,
+    boothType: {
+      korean: '주점',
+    },
+    location: '명진관 9번',
     notice: '호떡이 참 맛있는 맛집',
-    day: [29, 30],
+    startAt: '2022-09-23',
     content:
       '맛있는 호떡 먹고 가세요~ 맛있는 호떡 먹고 가세요 피자, 슈크림, 등 다양한 맛을 판매 중입니다.~',
     images: [
@@ -45,7 +52,6 @@ export default function BoothDetail() {
       },
     ],
   });
-
   const [menu, setMenu] = useState([
     {
       name: '호떡',
@@ -71,7 +77,7 @@ export default function BoothDetail() {
 
   return (
     <div style={{ marginBottom: '76px' }}>
-      <UpTitle title={`${booth.type} 홈페이지`} mapleLeft="57px" />
+      <UpTitle title={`${booth.boothType.korean} 홈페이지`} mapleLeft="57px" />
 
       {/* 스와이퍼 */}
       <SwiperContainer>
@@ -89,7 +95,7 @@ export default function BoothDetail() {
 
       {/* 부스 내용 */}
       <ContentContainer>
-        <TypeBtn tp={booth.type}>주점</TypeBtn>
+        <TypeBtn tp={booth.boothType.korean}>{booth.boothType.korean}</TypeBtn>
         <BoothTitle>{booth.title}</BoothTitle>
         <BoothIntro>{booth.introduction}</BoothIntro>
         <br />
@@ -99,6 +105,21 @@ export default function BoothDetail() {
           &nbsp;
           <LikeCnt>100</LikeCnt>
         </div>
+
+        <DateLocContainer>
+          <div>{booth.startAt.slice(8, 10)}일</div>&nbsp;
+          <LocationMap>
+            <img src={MapIconImg} width="24" height="26" />
+            {booth.location}
+          </LocationMap>
+        </DateLocContainer>
+        <BoothNotification>
+          <NotificationsIcon
+            style={{ fontSize: '16px', margin: '6px 6px 0 14px' }}
+          />
+          <div>부스 공지사항</div>
+          <KeyboardArrowDownIcon style={{ margin: '3px 14px 6px auto' }} />
+        </BoothNotification>
       </ContentContainer>
     </div>
   );

--- a/src/pages/Booth/style.js
+++ b/src/pages/Booth/style.js
@@ -91,4 +91,85 @@ export const BoothNotification = styled.div`
   background: rgba(255, 255, 255, 0.2);
   border-radius: 10px;
   margin-top: 18px;
+  cursor: pointer;
+`;
+
+export const BoothNotificationOpen = styled.div`
+  display: flex;
+  width: 100%;
+  margin-top: 18px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
+
+  & > div {
+    display: flex;
+    align-item: center;
+    width: 100%;
+    height: 28px;
+    line-height: 30px;
+    font-weight: 800;
+    font-size: 13px;
+  }
+`;
+
+export const IntroContainer = styled.div`
+  width: 100%;
+  margin-top: 21px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+
+  & > .introtitle {
+    display: flex;
+    height: 26px;
+    align-item: center;
+    margin: 7px 0 3px 0;
+  }
+
+  & > div > span {
+    line-height: 30px;
+    font-size: 16px;
+    font-weight: 800;
+  }
+
+  & > span {
+    // font-size: 12px;
+    margin-right: auto;
+    border-bottom: 0.3px solid #fff;
+  }
+`;
+
+export const IntroLine = styled.p`
+  width: 100%;
+  height: 0;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  box-shadow: 0px 2px 4px rgba(255, 255, 255, 0.5);
+  transform: rotate(-0.29deg);
+  margin: 0;
+`;
+
+export const IntroContent = styled.div`
+  width: 100%;
+  margin-top: 19px;
+  text-align: left;
+  font-size: 12px;
+`;
+
+export const MenuContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const MenuItem = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+
+  & > div {
+    height: 21px;
+    font-size: 16px;
+    font-weight: 500;
+    margin-top: 8px;
+  }
 `;

--- a/src/pages/Booth/style.js
+++ b/src/pages/Booth/style.js
@@ -98,10 +98,11 @@ export const BoothNotificationOpen = styled.div`
   display: flex;
   width: 100%;
   margin-top: 18px;
+  flex-direction: column;
   background: rgba(255, 255, 255, 0.2);
   border-radius: 10px;
 
-  & > div {
+  & > .bar {
     display: flex;
     align-item: center;
     width: 100%;
@@ -109,6 +110,13 @@ export const BoothNotificationOpen = styled.div`
     line-height: 30px;
     font-weight: 800;
     font-size: 13px;
+  }
+  & > .notice {
+    width: 270px;
+    font-weight: 200;
+    font-size: 10px;
+    text-align: left;
+    margin: 2px 14px 13px 30px;
   }
 `;
 

--- a/src/pages/Booth/style.js
+++ b/src/pages/Booth/style.js
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { baseColor } from '../../styles/GlobalStyle';
 
 export const SwiperContainer = styled.div`
   width: 370px;
@@ -29,6 +30,14 @@ export const TypeBtn = styled.button`
       return css`
         background-color: #ff6b6b;
       `;
+    } else if (props.tp === '부스') {
+      return css`
+        background-color: #0b9908;
+      `;
+    } else if (props.tp === '푸드트럭') {
+      return css`
+        background-color: #2676ee;
+      `;
     }
   }}
 `;
@@ -49,4 +58,37 @@ export const BoothIntro = styled.p`
 export const LikeCnt = styled.span`
   font-size: 15px;
   line-height: 36px;
+`;
+
+export const DateLocContainer = styled.div`
+  width: 100%;
+  display: flex;
+  align-item: center;
+  font-size: 16px;
+`;
+
+export const LocationMap = styled.div`
+  display: flex;
+  align-item: center;
+  justify-content: space-between;
+  font-size: 16px;
+  color: ${baseColor};
+
+  & > img {
+    width: 30px;
+    margin: 0 auto;
+  }
+`;
+
+export const BoothNotification = styled.div`
+  display: flex;
+  align-item: center;
+  width: 100%;
+  height: 28px;
+  line-height: 30px;
+  font-weight: 800;
+  font-size: 13px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
+  margin-top: 18px;
 `;

--- a/src/pages/Notice/Notice.js
+++ b/src/pages/Notice/Notice.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import usePagination from '../../hooks/usePagination';
 
 import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
@@ -146,6 +146,10 @@ export default function Notice() {
       </NoticeCard>
     );
   });
+
+  useEffect(() => {
+    pageInfo.jump(1);
+  }, [option]);
 
   return (
     <>


### PR DESCRIPTION
# 1. 네브바 이슈 해결
#31 PR에서 오류를 겪은 이슈를 해결했습니다~

# 2. 공지사항 & 소개 & 메뉴 추가
디자인팀 사항대로 UI 화면 구성했습니다 (토글 모두 구현)
<img width="379" alt="스크린샷 2022-09-23 오후 11 12 43" src="https://user-images.githubusercontent.com/55776421/191980507-79095156-a0d3-4d08-bc83-98050ab3de6e.png">
<img width="375" alt="스크린샷 2022-09-23 오후 11 14 39" src="https://user-images.githubusercontent.com/55776421/191980916-c9c4472b-1a3e-402a-93b5-297f64305052.png">

여원이 요청대로 부스, 주점, 푸드트럭 별로 하트 색깔 다르게 해둠
<img width="377" alt="스크린샷 2022-09-23 오후 11 15 23" src="https://user-images.githubusercontent.com/55776421/191981070-019fc151-b820-4665-a91b-77d83664ffdc.png">
<img width="376" alt="스크린샷 2022-09-23 오후 11 16 04" src="https://user-images.githubusercontent.com/55776421/191981230-8c8e0606-7287-4210-9684-1a599173fb3e.png">
<img width="374" alt="스크린샷 2022-09-23 오후 11 16 27" src="https://user-images.githubusercontent.com/55776421/191981320-d494b27f-df3c-49d5-9c4f-895c35195a5d.png">

# 3. 공지사항 페이지 필터 이슈 해결
공지사항 페이지에서 페이지 네이션 2번에 있을 때 다른 카테고리를 클릭할 시 원하는 데이터가 나오지 않는 이슈를 해결했습니다.
`useEffect`로 페이지 렌더링해서 페이지 네이션 문제 해결
